### PR TITLE
Testing Baseline

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
@@ -76,6 +77,9 @@
     ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    },
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -43,6 +43,7 @@ enum Priority {
 type Query {
   me: User!
   task(id: ID!): Task
+  taskStats: TaskStats!
   tasks(filter: TaskFilterInput): [Task!]!
   user(id: ID!): User
   users: [User!]!
@@ -76,6 +77,14 @@ input TaskFilterInput {
   deadlineBefore: DateTime
   priority: Priority
   status: TaskStatus
+}
+
+type TaskStats {
+  done: Int!
+  inProgress: Int!
+  overdue: Int!
+  todo: Int!
+  total: Int!
 }
 
 enum TaskStatus {

--- a/apps/api/src/tasks/tasks.service.spec.ts
+++ b/apps/api/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,174 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Priority, TaskStatus } from '@/tasks/entities/task.entity';
+import { TasksService } from '@/tasks/tasks.service';
+import { PrismaService } from '@/prisma/prisma.service';
+
+type MockPrismaTask = {
+  findMany: jest.Mock;
+  findUnique: jest.Mock;
+  create: jest.Mock;
+  update: jest.Mock;
+  delete: jest.Mock;
+  count: jest.Mock;
+};
+
+function createPrismaMock(): PrismaService {
+  return {
+    task: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    },
+  } as unknown as PrismaService;
+}
+
+describe('TasksService', () => {
+  let service: TasksService;
+  let prisma: PrismaService;
+  let prismaTask: MockPrismaTask;
+
+  beforeEach(() => {
+    prisma = createPrismaMock();
+    prismaTask = prisma.task as unknown as MockPrismaTask;
+    service = new TasksService(prisma);
+  });
+
+  describe('findAll', () => {
+    it('builds filters and sorts by newest first', async () => {
+      const deadlineBefore = new Date('2026-04-30T00:00:00.000Z');
+      const deadlineAfter = new Date('2026-04-01T00:00:00.000Z');
+      prismaTask.findMany.mockResolvedValue([]);
+
+      await service.findAll('user-1', {
+        status: TaskStatus.IN_PROGRESS,
+        priority: Priority.HIGH,
+        deadlineBefore,
+        deadlineAfter,
+      });
+
+      expect(prismaTask.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: 'user-1',
+          status: 'IN_PROGRESS',
+          priority: 'HIGH',
+          deadline: {
+            lte: deadlineBefore,
+            gte: deadlineAfter,
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+  });
+
+  describe('findById', () => {
+    it('throws when task does not exist', async () => {
+      prismaTask.findUnique.mockResolvedValue(null);
+
+      await expect(service.findById('task-1', 'user-1')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('throws when task belongs to another user', async () => {
+      prismaTask.findUnique.mockResolvedValue({
+        id: 'task-1',
+        userId: 'user-2',
+      });
+
+      await expect(service.findById('task-1', 'user-1')).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('applies default status and priority', async () => {
+      prismaTask.create.mockResolvedValue({ id: 'task-1' });
+
+      await service.create('user-1', { title: 'Write tests' });
+
+      expect(prismaTask.create).toHaveBeenCalledWith({
+        data: {
+          title: 'Write tests',
+          status: 'TODO',
+          priority: 'MEDIUM',
+          userId: 'user-1',
+        },
+      });
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('updates status after ownership check', async () => {
+      prismaTask.findUnique.mockResolvedValue({
+        id: 'task-1',
+        userId: 'user-1',
+      });
+      prismaTask.update.mockResolvedValue({ id: 'task-1', status: 'DONE' });
+
+      await service.updateStatus('user-1', {
+        id: 'task-1',
+        status: TaskStatus.DONE,
+      });
+
+      expect(prismaTask.update).toHaveBeenCalledWith({
+        where: { id: 'task-1' },
+        data: { status: 'DONE' },
+      });
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes task after ownership check and returns true', async () => {
+      prismaTask.findUnique.mockResolvedValue({
+        id: 'task-1',
+        userId: 'user-1',
+      });
+      prismaTask.delete.mockResolvedValue({ id: 'task-1' });
+
+      await expect(service.remove('user-1', 'task-1')).resolves.toBe(true);
+      expect(prismaTask.delete).toHaveBeenCalledWith({
+        where: { id: 'task-1' },
+      });
+    });
+  });
+
+  describe('getStats', () => {
+    it('returns aggregated task counts including overdue', async () => {
+      prismaTask.count
+        .mockResolvedValueOnce(4)
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(1);
+
+      await expect(service.getStats('user-1')).resolves.toEqual({
+        total: 9,
+        todo: 4,
+        inProgress: 3,
+        done: 2,
+        overdue: 1,
+      });
+
+      expect(prismaTask.count).toHaveBeenNthCalledWith(1, {
+        where: { userId: 'user-1', status: 'TODO' },
+      });
+      expect(prismaTask.count).toHaveBeenNthCalledWith(2, {
+        where: { userId: 'user-1', status: 'IN_PROGRESS' },
+      });
+      expect(prismaTask.count).toHaveBeenNthCalledWith(3, {
+        where: { userId: 'user-1', status: 'DONE' },
+      });
+      expect(prismaTask.count).toHaveBeenNthCalledWith(4, {
+        where: {
+          userId: 'user-1',
+          status: { not: 'DONE' },
+          deadline: { lt: expect.any(Date) },
+        },
+      });
+    });
+  });
+});

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -1,25 +1,361 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { PrismaService } from './../src/prisma/prisma.service';
+import { Priority, TaskStatus } from './../src/tasks/entities/task.entity';
+import { Role } from './../src/users/entities/user.entity';
 
-describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+type StoredUser = {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+  role: Role;
+  createdAt: Date;
+  updatedAt: Date;
+};
 
-  beforeEach(async () => {
+type StoredTask = {
+  id: string;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: Priority;
+  deadline?: Date | null;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+describe('GraphQL auth + tasks (e2e)', () => {
+  let app: INestApplication;
+  let users: StoredUser[];
+  let tasks: StoredTask[];
+
+  const prismaMock = {
+    user: {
+      findUnique: jest.fn(
+        async ({ where }: { where: { id?: string; email?: string } }) => {
+          if (where.id) {
+            return users.find((user) => user.id === where.id) ?? null;
+          }
+          if (where.email) {
+            return (
+              users.find(
+                (user) =>
+                  user.email.toLowerCase() === where.email?.toLowerCase(),
+              ) ?? null
+            );
+          }
+          return null;
+        },
+      ),
+      create: jest.fn(
+        async ({
+          data,
+        }: {
+          data: Omit<StoredUser, 'id' | 'createdAt' | 'updatedAt' | 'role'> &
+            Partial<Pick<StoredUser, 'role'>>;
+        }) => {
+          const now = new Date();
+          const user: StoredUser = {
+            id: `user-${users.length + 1}`,
+            name: data.name,
+            email: data.email,
+            password: data.password,
+            role: data.role ?? Role.USER,
+            createdAt: now,
+            updatedAt: now,
+          };
+          users.push(user);
+          return user;
+        },
+      ),
+    },
+    task: {
+      findMany: jest.fn(async ({ where }: { where: { userId: string } }) => {
+        return tasks
+          .filter((task) => task.userId === where.userId)
+          .sort(
+            (left, right) =>
+              right.createdAt.getTime() - left.createdAt.getTime(),
+          );
+      }),
+      findUnique: jest.fn(async ({ where }: { where: { id: string } }) => {
+        return tasks.find((task) => task.id === where.id) ?? null;
+      }),
+      create: jest.fn(
+        async ({
+          data,
+        }: {
+          data: Omit<StoredTask, 'id' | 'createdAt' | 'updatedAt'>;
+        }) => {
+          const now = new Date();
+          const task: StoredTask = {
+            id: `task-${tasks.length + 1}`,
+            title: data.title,
+            description: data.description,
+            status: data.status,
+            priority: data.priority,
+            deadline: data.deadline ?? null,
+            userId: data.userId,
+            createdAt: now,
+            updatedAt: now,
+          };
+          tasks.push(task);
+          return task;
+        },
+      ),
+      update: jest.fn(
+        async ({
+          where,
+          data,
+        }: {
+          where: { id: string };
+          data: Partial<StoredTask>;
+        }) => {
+          const task = tasks.find((item) => item.id === where.id);
+          if (!task) return null;
+          Object.assign(task, data, { updatedAt: new Date() });
+          return task;
+        },
+      ),
+      delete: jest.fn(async ({ where }: { where: { id: string } }) => {
+        const index = tasks.findIndex((task) => task.id === where.id);
+        if (index === -1) return null;
+        const [task] = tasks.splice(index, 1);
+        return task;
+      }),
+      count: jest.fn(
+        async ({
+          where,
+        }: {
+          where: {
+            userId: string;
+            status?: TaskStatus | { not: TaskStatus };
+            deadline?: { lt?: Date };
+          };
+        }) => {
+          return tasks.filter((task) => {
+            if (task.userId !== where.userId) return false;
+            if (
+              typeof where.status === 'string' &&
+              task.status !== where.status
+            ) {
+              return false;
+            }
+            if (
+              where.status &&
+              typeof where.status === 'object' &&
+              'not' in where.status &&
+              task.status === where.status.not
+            ) {
+              return false;
+            }
+            if (where.deadline?.lt) {
+              if (!task.deadline || !(task.deadline < where.deadline.lt)) {
+                return false;
+              }
+            }
+            return true;
+          }).length;
+        },
+      ),
+    },
+  } as unknown as PrismaService;
+
+  async function graphql<TData>(
+    query: string,
+    variables?: Record<string, unknown>,
+    token?: string,
+  ) {
+    const req = request(app.getHttpServer())
+      .post('/graphql')
+      .send({ query, variables });
+    if (token) {
+      req.set('Authorization', `Bearer ${token}`);
+    }
+    return req.expect(200) as Promise<{
+      body: { data?: TData; errors?: Array<{ message: string }> };
+    }>;
+  }
+
+  beforeAll(async () => {
+    process.env.JWT_SECRET = 'test-secret';
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(PrismaService)
+      .useValue(prismaMock)
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+  beforeEach(() => {
+    users = [];
+    tasks = [];
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('registers, logs in, creates a task, and returns task stats', async () => {
+    const registerMutation = `
+      mutation Register($input: RegisterInput!) {
+        register(input: $input) {
+          accessToken
+          user {
+            id
+            email
+            name
+            role
+          }
+        }
+      }
+    `;
+    const loginMutation = `
+      mutation Login($input: LoginInput!) {
+        login(input: $input) {
+          accessToken
+          user {
+            id
+            email
+          }
+        }
+      }
+    `;
+    const createTaskMutation = `
+      mutation CreateTask($input: CreateTaskInput!) {
+        createTask(input: $input) {
+          id
+          title
+          status
+          priority
+          userId
+        }
+      }
+    `;
+    const taskStatsQuery = `
+      query TaskStats {
+        taskStats {
+          total
+          todo
+          inProgress
+          done
+          overdue
+        }
+      }
+    `;
+
+    const registerResponse = await graphql<{
+      register: {
+        accessToken: string;
+        user: { id: string; email: string; name: string; role: Role };
+      };
+    }>(registerMutation, {
+      input: {
+        name: 'Test User',
+        email: 'user@example.com',
+        password: 'password123',
+      },
+    });
+
+    expect(registerResponse.body.errors).toBeUndefined();
+    expect(registerResponse.body.data?.register.user).toMatchObject({
+      email: 'user@example.com',
+      name: 'Test User',
+      role: 'USER',
+    });
+
+    const loginResponse = await graphql<{
+      login: { accessToken: string; user: { id: string; email: string } };
+    }>(loginMutation, {
+      input: {
+        email: 'user@example.com',
+        password: 'password123',
+      },
+    });
+
+    expect(loginResponse.body.errors).toBeUndefined();
+    const accessToken = loginResponse.body.data?.login.accessToken;
+    expect(accessToken).toBeTruthy();
+
+    const createTaskResponse = await graphql<{
+      createTask: {
+        id: string;
+        title: string;
+        status: TaskStatus;
+        priority: Priority;
+        userId: string;
+      };
+    }>(
+      createTaskMutation,
+      {
+        input: {
+          title: 'Ship TaskHub',
+        },
+      },
+      accessToken,
+    );
+
+    expect(createTaskResponse.body.errors).toBeUndefined();
+    expect(createTaskResponse.body.data?.createTask).toMatchObject({
+      title: 'Ship TaskHub',
+      status: 'TODO',
+      priority: 'MEDIUM',
+      userId: registerResponse.body.data?.register.user.id,
+    });
+
+    tasks.push({
+      id: 'task-overdue',
+      title: 'Old task',
+      status: TaskStatus.IN_PROGRESS,
+      priority: Priority.HIGH,
+      deadline: new Date('2026-01-01T00:00:00.000Z'),
+      userId: registerResponse.body.data!.register.user.id,
+      createdAt: new Date('2026-01-02T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+
+    const statsResponse = await graphql<{
+      taskStats: {
+        total: number;
+        todo: number;
+        inProgress: number;
+        done: number;
+        overdue: number;
+      };
+    }>(taskStatsQuery, undefined, accessToken);
+
+    expect(statsResponse.body.errors).toBeUndefined();
+    expect(statsResponse.body.data?.taskStats).toEqual({
+      total: 2,
+      todo: 1,
+      inProgress: 1,
+      done: 0,
+      overdue: 1,
+    });
+  });
+
+  it('rejects protected task operations without a token', async () => {
+    const createTaskMutation = `
+      mutation CreateTask($input: CreateTaskInput!) {
+        createTask(input: $input) {
+          id
+        }
+      }
+    `;
+
+    const response = await graphql(createTaskMutation, {
+      input: { title: 'Unauthorized task' },
+    });
+
+    expect(response.body.data).toBeNull();
+    expect(response.body.errors?.[0]?.message).toContain('Unauthorized');
   });
 });

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -3,6 +3,9 @@
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
+  "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/../src/$1"
+  },
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "graphql": "^16.13.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "web": "turbo run dev --filter=@taskhub/web",
     "build": "turbo run build",
     "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "prisma:generate": "yarn workspace @taskhub/database prisma:generate",
     "prisma:migrate": "yarn workspace @taskhub/database prisma:migrate",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,6 +6,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:migrate:create": "prisma migrate dev --create-only",


### PR DESCRIPTION
- Add TaskStats entity, taskStats query, and getStats service method
- Add unit tests for TasksService (7 cases covering filters, auth, defaults, stats)
- Replace placeholder e2e test with real GraphQL auth/tasks flow (2 cases)
- Fix Jest moduleNameMapper for @/ alias in both unit and e2e configs
- Add typecheck scripts to all packages and monorepo root via turbo