### PR TITLE
Split-card Auth Layout & UI Polish

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  client: {
+    service: {
+      name: "taskhub",
+      localSchemaFile: "./apps/api/src/schema.gql",
+    },
+    includes: ["./apps/web/src/**/*.{ts,tsx}"],
+  },
+};

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -6,63 +6,58 @@ import { login } from "@/app/actions/auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AuthCard } from "@/components/custom/AuthCard";
 
 export default function LoginPage() {
   const [state, action, pending] = useActionState(login, undefined);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
-      <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle className="text-2xl">Sign in</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form action={action} className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                required
-                autoComplete="email"
-                placeholder="you@example.com"
-              />
-            </div>
+    <AuthCard>
+      <h2 className="mb-6 text-center text-2xl font-semibold">Sign in</h2>
 
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                name="password"
-                type="password"
-                required
-                autoComplete="current-password"
-                placeholder="••••••••"
-              />
-            </div>
+      <form action={action} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            required
+            autoComplete="email"
+            placeholder="you@example.com"
+          />
+        </div>
 
-            {state?.error && (
-              <p className="text-sm text-destructive">{state.error}</p>
-            )}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            required
+            autoComplete="current-password"
+            placeholder="••••••••"
+          />
+        </div>
 
-            <Button type="submit" disabled={pending} className="mt-2 w-full">
-              {pending ? "Signing in…" : "Sign in"}
-            </Button>
-          </form>
+        {state?.error && (
+          <p className="text-sm text-destructive">{state.error}</p>
+        )}
 
-          <p className="mt-4 text-center text-sm text-muted-foreground">
-            No account?{" "}
-            <Link
-              href="/register"
-              className="font-medium text-foreground hover:underline"
-            >
-              Register
-            </Link>
-          </p>
-        </CardContent>
-      </Card>
-    </div>
+        <Button type="submit" disabled={pending} className="mt-2 w-full">
+          {pending ? "Signing in…" : "Sign in"}
+        </Button>
+      </form>
+
+      <p className="mt-4 text-center text-sm text-muted-foreground">
+        No account?{" "}
+        <Link
+          href="/register"
+          className="font-medium text-foreground hover:underline"
+        >
+          Register
+        </Link>
+      </p>
+    </AuthCard>
   );
 }

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -2,13 +2,13 @@
 
 import { useActionState, useState } from "react";
 import Link from "next/link";
-import { Eye, EyeOff } from "lucide-react";
+
 import { register } from "@/app/actions/auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { AuthCard } from "@/components/custom/AuthCard";
 
 const RULES = [
   {
@@ -62,140 +62,135 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
-      <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle className="text-2xl">Create account</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form
-            action={action}
-            onSubmit={handleSubmit}
-            className="flex flex-col gap-4"
-          >
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="name">Name</Label>
-              <Input
-                id="name"
-                name="name"
-                type="text"
-                required
-                autoComplete="name"
-                placeholder="Your name"
-              />
-            </div>
+    <AuthCard>
+      <h2 className="mb-6 text-center text-2xl font-semibold">Register</h2>
 
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                required
-                autoComplete="email"
-                placeholder="you@example.com"
-              />
-            </div>
+      <form
+        action={action}
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-4"
+      >
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="name">Name</Label>
+          <Input
+            id="name"
+            name="name"
+            type="text"
+            required
+            autoComplete="name"
+            placeholder="Your name"
+          />
+        </div>
 
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="password">Password</Label>
-              <div className="relative">
-                <Input
-                  id="password"
-                  name="password"
-                  type={showPassword ? "text" : "password"}
-                  required
-                  autoComplete="new-password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="pr-10"
-                  placeholder="••••••••"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  aria-label={showPassword ? "Hide password" : "Show password"}
-                >
-                  {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                </button>
-              </div>
-              {password.length > 0 && (
-                <ul className="mt-1 space-y-1">
-                  {RULES.map((rule) => {
-                    const passed = rule.test(password);
-                    return (
-                      <li
-                        key={rule.id}
-                        className={cn(
-                          "flex items-center gap-1.5 text-xs transition-colors",
-                          passed
-                            ? "text-green-600 dark:text-green-400"
-                            : "text-muted-foreground",
-                        )}
-                      >
-                        <span className="text-[10px]">
-                          {passed ? "✓" : "○"}
-                        </span>
-                        {rule.label}
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            required
+            autoComplete="email"
+            placeholder="you@example.com"
+          />
+        </div>
 
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="confirm">Confirm Password</Label>
-              <div className="relative">
-                <Input
-                  id="confirm"
-                  name="confirm"
-                  type={showConfirm ? "text" : "password"}
-                  required
-                  autoComplete="new-password"
-                  value={confirm}
-                  onChange={(e) => setConfirm(e.target.value)}
-                  className={cn(
-                    "pr-10",
-                    confirmMismatch &&
-                      "border-destructive focus-visible:ring-destructive/20",
-                  )}
-                  placeholder="••••••••"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirm((v) => !v)}
-                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  aria-label={showConfirm ? "Hide password" : "Show password"}
-                >
-                  {showConfirm ? <EyeOff size={16} /> : <Eye size={16} />}
-                </button>
-              </div>
-            </div>
-
-            {(clientError || state?.error) && (
-              <p className="text-sm text-destructive">
-                {clientError || state?.error}
-              </p>
-            )}
-
-            <Button type="submit" disabled={pending} className="mt-2 w-full">
-              {pending ? "Creating account…" : "Create account"}
-            </Button>
-          </form>
-
-          <p className="mt-4 text-center text-sm text-muted-foreground">
-            Already have an account?{" "}
-            <Link
-              href="/login"
-              className="font-medium text-foreground hover:underline"
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="password">Password</Label>
+          <div className="relative">
+            <Input
+              id="password"
+              name="password"
+              type={showPassword ? "text" : "password"}
+              required
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="pr-10"
+              placeholder="••••••••"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              disabled={!password}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
+              aria-label={showPassword ? "Hide password" : "Show password"}
             >
-              Sign in
-            </Link>
+              {showPassword ? "Hide" : "Show"}
+            </button>
+          </div>
+          {password.length > 0 && (
+            <ul className="mt-1 space-y-1">
+              {RULES.map((rule) => {
+                const passed = rule.test(password);
+                return (
+                  <li
+                    key={rule.id}
+                    className={cn(
+                      "flex items-center gap-1.5 text-xs transition-colors",
+                      passed
+                        ? "text-green-600 dark:text-green-400"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    <span className="text-[10px]">{passed ? "✓" : "○"}</span>
+                    {rule.label}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="confirm">Confirm Password</Label>
+          <div className="relative">
+            <Input
+              id="confirm"
+              name="confirm"
+              type={showConfirm ? "text" : "password"}
+              required
+              autoComplete="new-password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              className={cn(
+                "pr-10",
+                confirmMismatch &&
+                  "border-destructive focus-visible:ring-destructive/20",
+              )}
+              placeholder="••••••••"
+            />
+            <button
+              type="button"
+              onClick={() => setShowConfirm((v) => !v)}
+              disabled={!confirm}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
+              aria-label={showConfirm ? "Hide password" : "Show password"}
+            >
+              {showConfirm ? "Hide" : "Show"}
+            </button>
+          </div>
+        </div>
+
+        {(clientError || state?.error) && (
+          <p className="text-sm text-destructive">
+            {clientError || state?.error}
           </p>
-        </CardContent>
-      </Card>
-    </div>
+        )}
+
+        <Button type="submit" disabled={pending} className="mt-2 w-full">
+          {pending ? "Registering…" : "Register"}
+        </Button>
+      </form>
+
+      <p className="mt-4 text-center text-sm text-muted-foreground">
+        Already have an account?{" "}
+        <Link
+          href="/login"
+          className="font-medium text-foreground hover:underline"
+        >
+          Sign in
+        </Link>
+      </p>
+    </AuthCard>
   );
 }

--- a/apps/web/src/app/(dashboard)/dashboard/tasks/CreateTaskDialog.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tasks/CreateTaskDialog.tsx
@@ -37,7 +37,7 @@ export function CreateTaskDialog() {
 
       <dialog
         ref={dialogRef}
-        className="w-full max-w-md rounded-xl border bg-card text-card-foreground shadow-xl backdrop:bg-black/50 p-0"
+        className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md rounded-xl border bg-card text-card-foreground shadow-xl backdrop:bg-black/50 p-0 m-0"
       >
         <div className="p-6">
           <h2 className="text-lg font-semibold mb-1">New task</h2>

--- a/apps/web/src/app/(dashboard)/dashboard/tasks/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tasks/page.tsx
@@ -2,8 +2,8 @@ import { gql } from "graphql-request";
 import { getSession } from "@/lib/session";
 import { getClient } from "@/lib/graphql";
 import { redirect } from "next/navigation";
-import { CreateTaskDialog } from "./CreateTaskDialog";
-import { TaskItem } from "./TaskItem";
+import { CreateTaskDialog } from "@/app/(dashboard)/dashboard/tasks/CreateTaskDialog";
+import { TaskItem } from "@/app/(dashboard)/dashboard/tasks/TaskItem";
 
 const TASKS_QUERY = gql`
   query {

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
+import Link from "next/link";
 import { logout } from "@/app/actions/auth";
-import { NavLinks } from "./NavLinks";
+import { NavLinks } from "@/app/(dashboard)/NavLinks";
 import { Button } from "@/components/ui/button";
 
 export default function DashboardLayout({
@@ -13,7 +14,7 @@ export default function DashboardLayout({
       <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
         <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
           <div className="flex items-center gap-5">
-            <div className="flex items-center gap-2">
+            <Link href="/dashboard" className="flex items-center gap-2">
               <Image
                 src="/logo.svg"
                 alt="TaskHub logo"
@@ -25,7 +26,7 @@ export default function DashboardLayout({
               <span className="text-sm font-semibold tracking-tight">
                 TaskHub
               </span>
-            </div>
+            </Link>
             <NavLinks />
           </div>
           <form action={logout}>

--- a/apps/web/src/app/actions/auth.ts
+++ b/apps/web/src/app/actions/auth.ts
@@ -78,16 +78,14 @@ export async function register(
     return { error: "Password does not meet security requirements." };
 
   try {
-    const data = await getClient().request<{
+    await getClient().request<{
       register: { accessToken: string };
     }>(REGISTER_MUTATION, { input: { name, email, password } });
-
-    await createSession(data.register.accessToken);
   } catch {
     return { error: "Registration failed. Email may already be in use." };
   }
 
-  redirect("/dashboard");
+  redirect("/login");
 }
 
 export async function logout() {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3,57 +3,59 @@
 
 @custom-variant dark (&:is(.dark *));
 
-:root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.82);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.82);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.82);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-}
+@layer base {
+  :root {
+    --radius: 0.625rem;
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.141 0.005 285.82);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.141 0.005 285.82);
+    --popover: oklch(1 0 0);
+    --popover-foreground: oklch(0.141 0.005 285.82);
+    --primary: oklch(0.21 0.006 285.885);
+    --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.967 0.001 286.375);
+    --secondary-foreground: oklch(0.21 0.006 285.885);
+    --muted: oklch(0.967 0.001 286.375);
+    --muted-foreground: oklch(0.552 0.016 285.938);
+    --accent: oklch(0.967 0.001 286.375);
+    --accent-foreground: oklch(0.21 0.006 285.885);
+    --destructive: oklch(0.577 0.245 27.325);
+    --border: oklch(0.92 0.004 286.32);
+    --input: oklch(0.92 0.004 286.32);
+    --ring: oklch(0.705 0.015 286.067);
+    --chart-1: oklch(0.646 0.222 41.116);
+    --chart-2: oklch(0.6 0.118 184.704);
+    --chart-3: oklch(0.398 0.07 227.392);
+    --chart-4: oklch(0.828 0.189 84.429);
+    --chart-5: oklch(0.769 0.188 70.08);
+  }
 
-.dark {
-  --background: oklch(0.141 0.005 285.82);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
+  .dark {
+    --background: oklch(0.141 0.005 285.82);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.21 0.006 285.885);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.21 0.006 285.885);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.92 0.004 286.32);
+    --primary-foreground: oklch(0.21 0.006 285.885);
+    --secondary: oklch(0.274 0.006 286.033);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.274 0.006 286.033);
+    --muted-foreground: oklch(0.705 0.015 286.067);
+    --accent: oklch(0.274 0.006 286.033);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.552 0.016 285.938);
+    --chart-1: oklch(0.488 0.243 264.376);
+    --chart-2: oklch(0.696 0.17 162.48);
+    --chart-3: oklch(0.769 0.188 70.08);
+    --chart-4: oklch(0.627 0.265 303.9);
+    --chart-5: oklch(0.645 0.246 16.439);
+  }
 }
 
 @theme inline {
@@ -95,9 +97,4 @@
 body {
   background-color: var(--color-background);
   color: var(--color-foreground);
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
 }

--- a/apps/web/src/components/custom/AppBranding.tsx
+++ b/apps/web/src/components/custom/AppBranding.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+interface AppBrandingProps {
+  variant?: "light" | "dark";
+}
+
+export function AppBranding({ variant = "light" }: AppBrandingProps) {
+  const isDark = variant === "dark";
+  return (
+    <div className="flex flex-col items-center text-center">
+      <Image
+        src="/logo.svg"
+        alt="TaskHub logo"
+        width={80}
+        height={80}
+        className={isDark ? "invert" : "dark:invert"}
+      />
+      <h1
+        className={cn(
+          "mt-4 text-5xl font-bold tracking-tight",
+          isDark && "text-white",
+        )}
+      >
+        TaskHub
+      </h1>
+      <p
+        className={cn(
+          "mt-1.5 text-xs",
+          isDark ? "text-zinc-700" : "text-muted-foreground",
+        )}
+      >
+        Track, prioritize, and ship — effortlessly.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/custom/AuthCard.tsx
+++ b/apps/web/src/components/custom/AuthCard.tsx
@@ -1,0 +1,16 @@
+import { AppBranding } from "@/components/custom/AppBranding";
+
+export function AuthCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4 py-8">
+      <div className="flex min-h-150 w-full max-w-4xl overflow-hidden rounded-xl bg-background shadow-lg">
+        <div className="hidden w-1/2 flex-col items-center justify-center bg-zinc-900 p-10 md:flex">
+          <AppBranding variant="dark" />
+        </div>
+        <div className="flex w-full flex-col justify-center p-8 md:w-1/2 md:px-12">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -8,14 +8,14 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
-        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-none transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground/25 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "focus-visible:border-ring focus:placeholder:text-transparent",
         "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };


### PR DESCRIPTION
- Split-card layout: dark branding left, form right (AuthCard component)
- AppBranding component with dark/light variant
- Remove focus ring on inputs, softer placeholder text, no input shadow
- Register redirects to login instead of auto-login
- Dialog centering, logo links to dashboard
- Show/Hide text toggle for passwords (disabled when empty)
- Placeholder hides on focus
- Fix CSS variables with @layer base for Tailwind v4
- Replace all relative imports with absolute @/ paths
- Add Apollo GraphQL config