### PR TITLE
Filter, Sort, Pagination

### DIFF
--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -44,7 +44,8 @@ type Query {
   me: User!
   task(id: ID!): Task
   taskStats: TaskStats!
-  tasks(filter: TaskFilterInput): [Task!]!
+  tasks(filter: TaskFilterInput, skip: Int, take: Int): [Task!]!
+  tasksCount(filter: TaskFilterInput): Int!
   user(id: ID!): User
   users: [User!]!
 }
@@ -58,6 +59,18 @@ input RegisterInput {
 enum Role {
   ADMIN
   USER
+}
+
+enum SortBy {
+  CREATED_AT
+  DEADLINE
+  PRIORITY
+  TITLE
+}
+
+enum SortOrder {
+  ASC
+  DESC
 }
 
 type Task {
@@ -76,6 +89,8 @@ input TaskFilterInput {
   deadlineAfter: DateTime
   deadlineBefore: DateTime
   priority: Priority
+  sortBy: SortBy
+  sortOrder: SortOrder
   status: TaskStatus
 }
 

--- a/apps/api/src/tasks/dto/task-filter.input.ts
+++ b/apps/api/src/tasks/dto/task-filter.input.ts
@@ -1,6 +1,21 @@
-import { InputType, Field } from '@nestjs/graphql';
+import { InputType, Field, registerEnumType } from '@nestjs/graphql';
 import { TaskStatus } from '@/tasks/entities/task.entity';
 import { Priority } from '@/tasks/entities/task.entity';
+
+export enum SortBy {
+  CREATED_AT = 'createdAt',
+  DEADLINE = 'deadline',
+  PRIORITY = 'priority',
+  TITLE = 'title',
+}
+
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+registerEnumType(SortBy, { name: 'SortBy' });
+registerEnumType(SortOrder, { name: 'SortOrder' });
 
 @InputType()
 export class TaskFilterInput {
@@ -15,4 +30,10 @@ export class TaskFilterInput {
 
   @Field({ nullable: true })
   deadlineAfter?: Date;
+
+  @Field(() => SortBy, { nullable: true })
+  sortBy?: SortBy;
+
+  @Field(() => SortOrder, { nullable: true })
+  sortOrder?: SortOrder;
 }

--- a/apps/api/src/tasks/tasks.resolver.ts
+++ b/apps/api/src/tasks/tasks.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver, Query, Mutation, Args, ID } from '@nestjs/graphql';
+import { Resolver, Query, Mutation, Args, ID, Int } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
 import { TasksService } from '@/tasks/tasks.service';
 import { Task } from '@/tasks/entities/task.entity';
@@ -22,8 +22,19 @@ export class TasksResolver {
     @CurrentUser() user: User,
     @Args('filter', { type: () => TaskFilterInput, nullable: true })
     filter?: TaskFilterInput,
+    @Args('skip', { type: () => Int, nullable: true }) skip?: number,
+    @Args('take', { type: () => Int, nullable: true }) take?: number,
   ): Promise<PrismaTask[]> {
-    return this.tasksService.findAll(user.id, filter);
+    return this.tasksService.findAll(user.id, filter, skip, take);
+  }
+
+  @Query(() => Int, { name: 'tasksCount' })
+  countAll(
+    @CurrentUser() user: User,
+    @Args('filter', { type: () => TaskFilterInput, nullable: true })
+    filter?: TaskFilterInput,
+  ): Promise<number> {
+    return this.tasksService.countAll(user.id, filter);
   }
 
   @Query(() => TaskStats, { name: 'taskStats' })

--- a/apps/api/src/tasks/tasks.service.spec.ts
+++ b/apps/api/src/tasks/tasks.service.spec.ts
@@ -60,6 +60,8 @@ describe('TasksService', () => {
           },
         },
         orderBy: { createdAt: 'desc' },
+        skip: 0,
+        take: undefined,
       });
     });
   });

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -7,7 +7,11 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { CreateTaskInput } from '@/tasks/dto/create-task.input';
 import { UpdateTaskInput } from '@/tasks/dto/update-task.input';
 import { UpdateTaskStatusInput } from '@/tasks/dto/update-task-status.input';
-import { TaskFilterInput } from '@/tasks/dto/task-filter.input';
+import {
+  TaskFilterInput,
+  SortBy,
+  SortOrder,
+} from '@/tasks/dto/task-filter.input';
 import { TaskStatus, Priority } from '@/tasks/entities/task.entity';
 import { TaskStats } from '@/tasks/entities/task-stats.entity';
 import type { Task } from '@prisma/client';
@@ -21,7 +25,12 @@ import {
 export class TasksService {
   constructor(private readonly prisma: PrismaService) {}
 
-  findAll(userId: string, filter?: TaskFilterInput): Promise<Task[]> {
+  findAll(
+    userId: string,
+    filter?: TaskFilterInput,
+    skip?: number,
+    take?: number,
+  ): Promise<Task[]> {
     const where: Prisma.TaskWhereInput = { userId };
 
     if (filter?.status)
@@ -38,7 +47,41 @@ export class TasksService {
           filter.deadlineAfter;
     }
 
-    return this.prisma.task.findMany({ where, orderBy: { createdAt: 'desc' } });
+    const sortBy = filter?.sortBy ?? SortBy.CREATED_AT;
+    const sortOrder = filter?.sortOrder ?? SortOrder.DESC;
+    const orderBy: Prisma.TaskOrderByWithRelationInput =
+      sortBy === SortBy.PRIORITY
+        ? { priority: sortOrder }
+        : sortBy === SortBy.DEADLINE
+          ? { deadline: sortOrder }
+          : sortBy === SortBy.TITLE
+            ? { title: sortOrder }
+            : { createdAt: sortOrder };
+
+    return this.prisma.task.findMany({
+      where,
+      orderBy,
+      skip: skip ?? 0,
+      take: take ?? undefined,
+    });
+  }
+
+  countAll(userId: string, filter?: TaskFilterInput): Promise<number> {
+    const where: Prisma.TaskWhereInput = { userId };
+    if (filter?.status)
+      where.status = filter.status as unknown as PrismaTaskStatus;
+    if (filter?.priority)
+      where.priority = filter.priority as unknown as PrismaPriority;
+    if (filter?.deadlineBefore || filter?.deadlineAfter) {
+      where.deadline = {};
+      if (filter.deadlineBefore)
+        (where.deadline as Prisma.DateTimeNullableFilter).lte =
+          filter.deadlineBefore;
+      if (filter.deadlineAfter)
+        (where.deadline as Prisma.DateTimeNullableFilter).gte =
+          filter.deadlineAfter;
+    }
+    return this.prisma.task.count({ where });
   }
 
   async findById(id: string, userId: string): Promise<Task> {

--- a/apps/web/src/app/(dashboard)/dashboard/tasks/TaskFilters.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tasks/TaskFilters.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useCallback } from "react";
+
+const STATUS_OPTIONS = [
+  { label: "All statuses", value: "" },
+  { label: "To Do", value: "TODO" },
+  { label: "In Progress", value: "IN_PROGRESS" },
+  { label: "Done", value: "DONE" },
+];
+
+const PRIORITY_OPTIONS = [
+  { label: "All priorities", value: "" },
+  { label: "Low", value: "LOW" },
+  { label: "Medium", value: "MEDIUM" },
+  { label: "High", value: "HIGH" },
+];
+
+const SORT_OPTIONS = [
+  { label: "Newest first", value: "createdAt:desc" },
+  { label: "Oldest first", value: "createdAt:asc" },
+  { label: "Deadline ↑", value: "deadline:asc" },
+  { label: "Deadline ↓", value: "deadline:desc" },
+  { label: "Priority ↑", value: "priority:asc" },
+  { label: "Priority ↓", value: "priority:desc" },
+  { label: "Title A–Z", value: "title:asc" },
+  { label: "Title Z–A", value: "title:desc" },
+];
+
+const selectCls =
+  "h-8 rounded-md border border-input bg-background px-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50";
+
+export function TaskFilters() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+
+  const update = useCallback(
+    (key: string, value: string) => {
+      const next = new URLSearchParams(params.toString());
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      next.delete("page"); // reset to page 1 on filter change
+      router.replace(`${pathname}?${next.toString()}`);
+    },
+    [router, pathname, params],
+  );
+
+  const sort = params.get("sort") ?? "createdAt:desc";
+  const status = params.get("status") ?? "";
+  const priority = params.get("priority") ?? "";
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <select
+        className={selectCls}
+        value={status}
+        onChange={(e) => update("status", e.target.value)}
+        aria-label="Filter by status"
+      >
+        {STATUS_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+
+      <select
+        className={selectCls}
+        value={priority}
+        onChange={(e) => update("priority", e.target.value)}
+        aria-label="Filter by priority"
+      >
+        {PRIORITY_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+
+      <select
+        className={selectCls}
+        value={sort}
+        onChange={(e) => update("sort", e.target.value)}
+        aria-label="Sort tasks"
+      >
+        {SORT_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/tasks/TaskPagination.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tasks/TaskPagination.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+const PAGE_SIZE = 10;
+
+export function TaskPagination({
+  total,
+  page,
+}: {
+  total: number;
+  page: number;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  function goTo(p: number) {
+    const next = new URLSearchParams(params.toString());
+    if (p === 1) {
+      next.delete("page");
+    } else {
+      next.set("page", String(p));
+    }
+    router.replace(`${pathname}?${next.toString()}`);
+  }
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="mt-6 flex items-center justify-between gap-4">
+      <p className="text-sm text-muted-foreground">
+        Page {page} of {totalPages} &middot; {total} tasks
+      </p>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => goTo(page - 1)}
+          disabled={page <= 1}
+          aria-label="Previous page"
+        >
+          <ChevronLeft size={14} />
+        </Button>
+
+        {Array.from({ length: totalPages }, (_, i) => i + 1)
+          .filter((p) => p === 1 || p === totalPages || Math.abs(p - page) <= 1)
+          .reduce<(number | "…")[]>((acc, p, idx, arr) => {
+            if (idx > 0 && (p as number) - (arr[idx - 1] as number) > 1)
+              acc.push("…");
+            acc.push(p);
+            return acc;
+          }, [])
+          .map((p, i) =>
+            p === "…" ? (
+              <span
+                key={`ellipsis-${i}`}
+                className="px-1 text-sm text-muted-foreground"
+              >
+                …
+              </span>
+            ) : (
+              <Button
+                key={p}
+                variant={p === page ? "default" : "outline"}
+                size="icon"
+                className="h-8 w-8 text-xs"
+                onClick={() => goTo(p as number)}
+                aria-label={`Page ${p}`}
+              >
+                {p}
+              </Button>
+            ),
+          )}
+
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => goTo(page + 1)}
+          disabled={page >= totalPages}
+          aria-label="Next page"
+        >
+          <ChevronRight size={14} />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/tasks/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tasks/page.tsx
@@ -1,40 +1,77 @@
 import { getSession } from "@/lib/session";
 import { getSdkClient } from "@/lib/graphql";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import { CreateTaskDialog } from "@/app/(dashboard)/dashboard/tasks/CreateTaskDialog";
 import { TaskItem } from "@/app/(dashboard)/dashboard/tasks/TaskItem";
+import { TaskFilters } from "@/app/(dashboard)/dashboard/tasks/TaskFilters";
+import { TaskPagination } from "@/app/(dashboard)/dashboard/tasks/TaskPagination";
 import type { GetTasksQuery } from "@/graphql/generated";
 
 type Task = GetTasksQuery["tasks"][number];
 
-export default async function TasksPage() {
+const PAGE_SIZE = 10;
+
+export default async function TasksPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string>>;
+}) {
   const token = await getSession();
   if (!token) redirect("/login");
 
+  const sp = await searchParams;
+  const page = Math.max(1, parseInt(sp.page ?? "1", 10));
+  const status = sp.status || undefined;
+  const priority = sp.priority || undefined;
+  const [rawSortBy, rawSortOrder] = (sp.sort ?? "createdAt:desc").split(":");
+  const sortBy = rawSortBy || undefined;
+  const sortOrder = rawSortOrder || undefined;
+
+  const filter = {
+    ...(status && { status }),
+    ...(priority && { priority }),
+    ...(sortBy && { sortBy }),
+    ...(sortOrder && { sortOrder }),
+  };
+
   let tasks: Task[] = [];
+  let total = 0;
+
   try {
-    const data = await getSdkClient(token).GetTasks();
-    tasks = data.tasks;
+    const sdk = getSdkClient(token);
+    const [tasksData, countData] = await Promise.all([
+      sdk.GetTasks({
+        filter: Object.keys(filter).length ? filter : undefined,
+        skip: (page - 1) * PAGE_SIZE,
+        take: PAGE_SIZE,
+      }),
+      sdk.GetTasksCount({
+        filter: Object.keys(filter).length ? filter : undefined,
+      }),
+    ]);
+    tasks = tasksData.tasks;
+    total = countData.tasksCount;
   } catch {
-    // token expired or API down — clear session handled by middleware
+    // token expired or API down
   }
 
   return (
     <div>
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
-          My Tasks
-        </h1>
-        <div className="flex items-center gap-3">
-          <span className="text-sm text-zinc-500">{tasks.length} tasks</span>
-          <CreateTaskDialog />
-        </div>
+      <div className="mb-5 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">My Tasks</h1>
+        <CreateTaskDialog />
+      </div>
+
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <Suspense>
+          <TaskFilters />
+        </Suspense>
+        <span className="text-sm text-muted-foreground">{total} tasks</span>
       </div>
 
       {tasks.length === 0 ? (
-        <p className="text-zinc-500">
-          No tasks yet. Create one to get started.
-        </p>
+        <p className="text-muted-foreground">No tasks match your filters.</p>
       ) : (
         <ul className="flex flex-col gap-3">
           {tasks.map((task) => (
@@ -42,6 +79,10 @@ export default async function TasksPage() {
           ))}
         </ul>
       )}
+
+      <Suspense>
+        <TaskPagination total={total} page={page} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/src/graphql/generated.ts
+++ b/apps/web/src/graphql/generated.ts
@@ -90,6 +90,7 @@ export type Query = {
   task?: Maybe<Task>;
   taskStats: TaskStats;
   tasks: Array<Task>;
+  tasksCount: Scalars['Int']['output'];
   user?: Maybe<User>;
   users: Array<User>;
 };
@@ -101,6 +102,13 @@ export type QueryTaskArgs = {
 
 
 export type QueryTasksArgs = {
+  filter?: InputMaybe<TaskFilterInput>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryTasksCountArgs = {
   filter?: InputMaybe<TaskFilterInput>;
 };
 
@@ -120,6 +128,18 @@ export enum Role {
   User = 'USER'
 }
 
+export enum SortBy {
+  CreatedAt = 'CREATED_AT',
+  Deadline = 'DEADLINE',
+  Priority = 'PRIORITY',
+  Title = 'TITLE'
+}
+
+export enum SortOrder {
+  Asc = 'ASC',
+  Desc = 'DESC'
+}
+
 export type Task = {
   __typename?: 'Task';
   createdAt: Scalars['DateTime']['output'];
@@ -137,6 +157,8 @@ export type TaskFilterInput = {
   deadlineAfter?: InputMaybe<Scalars['DateTime']['input']>;
   deadlineBefore?: InputMaybe<Scalars['DateTime']['input']>;
   priority?: InputMaybe<Priority>;
+  sortBy?: InputMaybe<SortBy>;
+  sortOrder?: InputMaybe<SortOrder>;
   status?: InputMaybe<TaskStatus>;
 };
 
@@ -219,10 +241,21 @@ export type GetTaskStatsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetTaskStatsQuery = { __typename?: 'Query', taskStats: { __typename?: 'TaskStats', total: number, todo: number, inProgress: number, done: number, overdue: number } };
 
-export type GetTasksQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetTasksQueryVariables = Exact<{
+  filter?: InputMaybe<TaskFilterInput>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  take?: InputMaybe<Scalars['Int']['input']>;
+}>;
 
 
 export type GetTasksQuery = { __typename?: 'Query', tasks: Array<{ __typename?: 'Task', id: string, title: string, description?: string | null, status: TaskStatus, priority: Priority, deadline?: any | null, createdAt: any }> };
+
+export type GetTasksCountQueryVariables = Exact<{
+  filter?: InputMaybe<TaskFilterInput>;
+}>;
+
+
+export type GetTasksCountQuery = { __typename?: 'Query', tasksCount: number };
 
 
 export const CreateTaskDocument = gql`
@@ -282,8 +315,8 @@ export const GetTaskStatsDocument = gql`
 }
     `;
 export const GetTasksDocument = gql`
-    query GetTasks {
-  tasks {
+    query GetTasks($filter: TaskFilterInput, $skip: Int, $take: Int) {
+  tasks(filter: $filter, skip: $skip, take: $take) {
     id
     title
     description
@@ -292,6 +325,11 @@ export const GetTasksDocument = gql`
     deadline
     createdAt
   }
+}
+    `;
+export const GetTasksCountDocument = gql`
+    query GetTasksCount($filter: TaskFilterInput) {
+  tasksCount(filter: $filter)
 }
     `;
 
@@ -322,6 +360,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetTasks(variables?: GetTasksQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetTasksQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetTasksQuery>({ document: GetTasksDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetTasks', 'query', variables);
+    },
+    GetTasksCount(variables?: GetTasksCountQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetTasksCountQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetTasksCountQuery>({ document: GetTasksCountDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetTasksCount', 'query', variables);
     }
   };
 }

--- a/apps/web/src/graphql/queries/getTasks.gql
+++ b/apps/web/src/graphql/queries/getTasks.gql
@@ -1,5 +1,5 @@
-query GetTasks {
-  tasks {
+query GetTasks($filter: TaskFilterInput, $skip: Int, $take: Int) {
+  tasks(filter: $filter, skip: $skip, take: $take) {
     id
     title
     description

--- a/apps/web/src/graphql/queries/getTasksCount.gql
+++ b/apps/web/src/graphql/queries/getTasksCount.gql
@@ -1,0 +1,3 @@
+query GetTasksCount($filter: TaskFilterInput) {
+  tasksCount(filter: $filter)
+}


### PR DESCRIPTION
API:
- TaskFilterInput: add SortBy and SortOrder enums
- TasksService.findAll: apply sortBy/sortOrder, accept skip/take
- TasksService.countAll: new method for total count
- TasksResolver: skip/take args on tasks query, new tasksCount query
- Fix tasks.service.spec.ts for updated findAll signature

Frontend:
- getTasks.gql: add $filter, $skip, $take variables
- getTasksCount.gql: new query
- TaskFilters component: status/priority/sort dropdowns via URL params
- TaskPagination component: page controls with ellipsis
- tasks/page.tsx: reads searchParams, calls both GetTasks + GetTasksCount
- Regenerate GraphQL SDK