### PR TITLE
Auth UI Improvements

### DIFF
--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthCard } from "@/components/custom/AuthCard";
+import { TermsDialog } from "@/components/custom/TermsDialog";
 
 export default function LoginPage() {
   const [state, action, pending] = useActionState(login, undefined);
@@ -48,16 +49,20 @@ export default function LoginPage() {
           {pending ? "Signing in…" : "Sign in"}
         </Button>
       </form>
-
-      <p className="mt-4 text-center text-sm text-muted-foreground">
-        No account?{" "}
-        <Link
-          href="/register"
-          className="font-medium text-foreground hover:underline"
-        >
-          Register
-        </Link>
-      </p>
+      <div className="mt-8">
+        <p className="mt-4 text-center text-xs text-muted-foreground">
+          By clicking Sign in, you agree to our <TermsDialog />
+        </p>
+        <p className="mt-4 text-center text-xs text-muted-foreground">
+          Don&apos;t have an account?{" "}
+          <Link
+            href="/register"
+            className="font-medium text-foreground hover:underline"
+          >
+            Register here
+          </Link>
+        </p>
+      </div>
     </AuthCard>
   );
 }

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { AuthCard } from "@/components/custom/AuthCard";
+import { TermsDialog } from "@/components/custom/TermsDialog";
 
 const RULES = [
   {
@@ -63,7 +64,7 @@ export default function RegisterPage() {
 
   return (
     <AuthCard>
-      <h2 className="mb-6 text-center text-2xl font-semibold">Register</h2>
+      <h2 className="mb-5 text-center text-2xl font-semibold">Register</h2>
 
       <form
         action={action}
@@ -180,15 +181,19 @@ export default function RegisterPage() {
         <Button type="submit" disabled={pending} className="mt-2 w-full">
           {pending ? "Registering…" : "Register"}
         </Button>
+
+        <p className="mt-4 text-center text-xs text-muted-foreground">
+          By clicking Register, you agree to our <TermsDialog />
+        </p>
       </form>
 
-      <p className="mt-4 text-center text-sm text-muted-foreground">
+      <p className="mt-4 text-center text-xs text-muted-foreground">
         Already have an account?{" "}
         <Link
           href="/login"
           className="font-medium text-foreground hover:underline"
         >
-          Sign in
+          Sign in here
         </Link>
       </p>
     </AuthCard>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3,6 +3,11 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@theme inline {
+  --font-sans: var(--font-comfortaa), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-comfortaa), ui-monospace, monospace;
+}
+
 @layer base {
   :root {
     --radius: 0.625rem;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,15 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Comfortaa } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const comfortaa = Comfortaa({
+  variable: "--font-comfortaa",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -25,7 +21,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${comfortaa.variable} h-full antialiased`}
       suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col">{children}</body>

--- a/apps/web/src/components/custom/AppBranding.tsx
+++ b/apps/web/src/components/custom/AppBranding.tsx
@@ -27,7 +27,7 @@ export function AppBranding({ variant = "light" }: AppBrandingProps) {
       <p
         className={cn(
           "mt-1.5 text-xs",
-          isDark ? "text-zinc-700" : "text-muted-foreground",
+          isDark ? "text-zinc-500" : "text-muted-foreground",
         )}
       >
         Track, prioritize, and ship — effortlessly.

--- a/apps/web/src/components/custom/AuthCard.tsx
+++ b/apps/web/src/components/custom/AuthCard.tsx
@@ -5,7 +5,12 @@ export function AuthCard({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4 py-8">
       <div className="flex min-h-150 w-full max-w-4xl overflow-hidden rounded-xl bg-background shadow-lg">
         <div className="hidden w-1/2 flex-col items-center justify-center bg-zinc-900 p-10 md:flex">
-          <AppBranding variant="dark" />
+          <div className="flex flex-1 items-center justify-center">
+            <AppBranding variant="dark" />
+          </div>
+          <p className="text-[11px] text-zinc-700">
+            &copy; {new Date().getFullYear()} taskhub. All Rights Reserved.
+          </p>
         </div>
         <div className="flex w-full flex-col justify-center p-8 md:w-1/2 md:px-12">
           {children}

--- a/apps/web/src/components/custom/TermsDialog.tsx
+++ b/apps/web/src/components/custom/TermsDialog.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { DialogOverlay, DialogPortal } from "@/components/ui/dialog";
+
+export function TermsDialog() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Trigger asChild>
+        <button
+          type="button"
+          className="font-medium text-foreground underline-offset-2 hover:underline"
+        >
+          Terms &amp; Conditions
+        </button>
+      </DialogPrimitive.Trigger>
+
+      <DialogPortal>
+        <DialogOverlay />
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-3 p-4">
+          <DialogPrimitive.Content className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg outline-none">
+            <DialogPrimitive.Title className="text-center mb-6 font-semibold leading-none">
+              Terms &amp; Conditions
+            </DialogPrimitive.Title>
+            <div className="space-y-5 text-xs leading-relaxed text-muted-foreground">
+              <section className="space-y-1.5">
+                <h3 className="font-semibold text-foreground">
+                  1. Acceptance of Terms
+                </h3>
+                <p>
+                  By accessing or using taskhub, you agree to be bound by these
+                  Terms &amp; Conditions. If you do not agree with any part of
+                  these terms, please do not use the service.
+                </p>
+              </section>
+
+              <section className="space-y-1.5">
+                <h3 className="font-semibold text-foreground">
+                  2. Use of Service
+                </h3>
+                <p>
+                  taskhub is a personal productivity tool. You are responsible
+                  for maintaining the confidentiality of your account
+                  credentials and for all activity that occurs under your
+                  account. You agree not to use the service for any unlawful
+                  purpose.
+                </p>
+              </section>
+
+              <section className="space-y-1.5">
+                <h3 className="font-semibold text-foreground">
+                  3. Data We Collect
+                </h3>
+                <p>
+                  We collect and store only the information necessary to provide
+                  the service:
+                </p>
+                <ul className="ml-4 list-disc space-y-1">
+                  <li>Your name and email address (used for authentication)</li>
+                  <li>Task data you create within the app</li>
+                  <li>Session tokens stored as secure, HTTP-only cookies</li>
+                </ul>
+                <p>
+                  We do not sell, share, or disclose your personal data to third
+                  parties.
+                </p>
+              </section>
+
+              <section className="space-y-1.5">
+                <h3 className="font-semibold text-foreground">
+                  4. Data Security
+                </h3>
+                <p>
+                  Passwords are hashed using industry-standard algorithms and
+                  are never stored in plain text. All data in transit is
+                  encrypted via HTTPS. Despite our efforts, no method of
+                  transmission over the internet is 100% secure.
+                </p>
+              </section>
+
+              <section className="space-y-1.5">
+                <h3 className="font-semibold text-foreground">
+                  5. Data Retention &amp; Deletion
+                </h3>
+                <p>
+                  Your data is retained for as long as your account remains
+                  active. You may request deletion of your account and all
+                  associated data at any time by contacting us.
+                </p>
+              </section>
+
+              <section className="space-y-1.5">
+                <h3 className="font-semibold text-foreground">
+                  6. Changes to These Terms
+                </h3>
+                <p>
+                  We may update these terms from time to time. Continued use of
+                  the service after changes are posted constitutes your
+                  acceptance of the revised terms.
+                </p>
+              </section>
+
+              <section className="space-y-1.5">
+                <h3 className="font-semibold text-foreground">7. Contact</h3>
+                <p>
+                  If you have any questions about these terms or your data,
+                  please reach out via the contact details provided in the app.
+                </p>
+              </section>
+            </div>
+          </DialogPrimitive.Content>
+        </div>
+      </DialogPortal>
+    </DialogPrimitive.Root>
+  );
+}


### PR DESCRIPTION
- Use Comfortaa font across entire app via next/font/google
- AuthCard: move copyright to bottom of dark panel
- TermsDialog component with 7-section privacy/terms content
- Login/register pages: Terms & Conditions clickable dialog
- Login: 'Don't have an account? Register here' link
- Register: 'Sign in here' link + terms notice