### PR TITLE
[Web - Tasks] Add Bulk Delete For Selected Tasks

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/TasksTable.tsx
+++ b/apps/web/src/app/(dashboard)/_components/TasksTable.tsx
@@ -49,7 +49,7 @@ import {
 
 import { CreateTaskDialog } from "@/app/(dashboard)/_components/CreateTaskDialog";
 import { EditTaskDialog } from "@/app/(dashboard)/_components/EditTaskDialog";
-import { deleteTask } from "@/app/actions/tasks";
+import { deleteTask, deleteTasks } from "@/app/actions/tasks";
 import { cn } from "@/lib/utils";
 import {
   TASK_PRIORITY_VISUAL,
@@ -229,6 +229,15 @@ export function TasksTable({ tasks, total, page, pageSize }: TasksTableProps) {
     startTransition(() => deleteTask(id));
   }
 
+  function handleDeleteSelected() {
+    const ids = Array.from(selected);
+    if (!confirm(`Delete ${ids.length} selected task${ids.length > 1 ? "s" : ""}?`)) return;
+    startTransition(async () => {
+      await deleteTasks(ids);
+      setSelected(new Set());
+    });
+  }
+
   // ── Pagination ─────────────────────────────────────────────────────────────
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -289,7 +298,20 @@ export function TasksTable({ tasks, total, page, pageSize }: TasksTableProps) {
             </Select>
           </div>
 
-          <CreateTaskDialog />
+          {selected.size > 0 ? (
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={isPending}
+              onClick={handleDeleteSelected}
+              className="shrink-0"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete {selected.size} selected
+            </Button>
+          ) : (
+            <CreateTaskDialog />
+          )}
         </div>
 
         {/* ── Table ── */}

--- a/apps/web/src/app/actions/tasks.ts
+++ b/apps/web/src/app/actions/tasks.ts
@@ -53,6 +53,17 @@ export async function deleteTask(id: string) {
   revalidatePath("/dashboard");
 }
 
+export async function deleteTasks(ids: string[]) {
+  const token = await getSession();
+  if (!token) return;
+
+  const sdk = getSdkClient(token);
+  await Promise.allSettled(ids.map((id) => sdk.DeleteTask({ id })));
+
+  revalidatePath("/dashboard/tasks");
+  revalidatePath("/dashboard");
+}
+
 export async function updateTask(
   _state: TaskFormState,
   formData: FormData,


### PR DESCRIPTION
## Summary

Adds a bulk delete action to the tasks table. Selecting one or more rows now reveals a delete button in the toolbar, replacing the create button while a selection is active.

## Changes

- Backend: N/A
- Frontend:
  + `actions/tasks.ts` — new `deleteTasks(ids: string[])` server action; calls `DeleteTask` for each id in parallel via `Promise.allSettled`, then revalidates both task and dashboard paths
  + `TasksTable.tsx` — toolbar right slot now conditionally renders a destructive "Delete N selected" button when `selected.size > 0`, or `CreateTaskDialog` when nothing is selected; clicking delete shows a native confirm, then fires the action and clears the selection
- Important logic: uses `Promise.allSettled` so a single failure does not block revalidation of the rest

## Testing

- Tested: select one task → delete button appears → confirm → task removed, selection cleared
- Tested: select multiple tasks → all deleted in one action
- Tested: cancel confirm → no deletion, selection preserved
- Regression test: N/A