### PR TITLE
[Web - Tasks] Replace Status And Priority Cells With Colored Badge Chips

### DIFF
--- a/apps/web/SKILL.md
+++ b/apps/web/SKILL.md
@@ -131,6 +131,48 @@ Rules:
 - Never call API endpoints directly from client components.
 - Server Components fetch data; Client Components handle interaction.
 
+## Design Tokens
+
+The color system uses a warm neutral palette. All token values live in `globals.css`; task-specific colors live in `lib/task-visuals.ts`.
+
+### Global palette (key tokens)
+
+| Token | Value | Role |
+|-------|-------|------|
+| `--background` | `oklch(1 0 0)` | Pure white page canvas |
+| `--foreground` | `oklch(0.09 0.008 65)` | Near-black with warm hue |
+| `--secondary` / `--muted` / `--accent` | `oklch(0.97 0.006 75)` | Warm white surface — yellow-brown undertone |
+| `--primary` | `oklch(0.52 0.18 247)` | Blue `#0075de` — the only saturated UI accent |
+| `--border` | `oklch(0 0 0 / 10%)` | Whisper border — ultra-thin, barely visible |
+| `--input` | `oklch(0.88 0 0)` | `#dddddd` input border |
+| `--destructive` | `oklch(0.55 0.22 25)` | Warm red for error/delete states |
+| `--radius` | `0.25rem` (4px) | Tight radius applied to all shadcn components |
+
+### Task visual colors (`lib/task-visuals.ts`)
+
+Status badges:
+
+| Status | Color | Hex |
+|--------|-------|-----|
+| Todo | Warm gray | `#a39e98` |
+| In Progress | Blue | `#0075de` |
+| Done | Green | `#1aae39` |
+
+Priority badges:
+
+| Priority | Color | Hex |
+|----------|-------|-----|
+| Low | Warm gray | `#a39e98` |
+| Medium | Orange | `#dd5b00` |
+| High | Red | `#e03131` |
+
+Rules:
+
+- NEVER add a new saturated color to the UI chrome — use CSS tokens only.
+- Status and priority chips are solid color badges with white centered text (`text-white font-medium`).
+- When adding a new task state or priority level, add its visual to `task-visuals.ts` following the warm neutral palette above; do not introduce colors outside this palette.
+- Dark mode mirrors the same palette with a warm dark brown-gray background (`oklch(0.24 0.010 65)`).
+
 ## Tailwind and UI Rules
 
 - Use design tokens from Tailwind config. No arbitrary values unless genuinely unavoidable.

--- a/apps/web/src/app/(dashboard)/_components/TasksTable.tsx
+++ b/apps/web/src/app/(dashboard)/_components/TasksTable.tsx
@@ -4,11 +4,6 @@ import { useMemo, useState, useTransition } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import {
   Circle,
-  CircleCheck,
-  Clock3,
-  ArrowUp,
-  ArrowRight,
-  ArrowDown,
   Search,
   SlidersHorizontal,
   MoreHorizontal,
@@ -65,47 +60,29 @@ type Task = GetTasksQuery["tasks"][number];
 
 const PAGE_SIZE_OPTIONS = [10, 20, 50];
 
-// ─── Icons ───────────────────────────────────────────────────────────────────
-
-const STATUS_ICON: Record<string, React.ElementType> = {
-  TODO: Circle,
-  IN_PROGRESS: Clock3,
-  DONE: CircleCheck,
-};
-
-const PRIORITY_ICON: Record<string, React.ElementType> = {
-  LOW: ArrowDown,
-  MEDIUM: ArrowRight,
-  HIGH: ArrowUp,
-};
-
 // ─── Sub-components ──────────────────────────────────────────────────────────
 
 function StatusCell({ status }: { status: string }) {
-  const Icon = STATUS_ICON[status] ?? Circle;
   const visual = TASK_STATUS_VISUAL[status as TaskStatusVisualKey];
   return (
-    <div
-      className="flex items-center gap-2 text-sm"
-      style={{ color: visual?.color }}
+    <span
+      className="inline-flex items-center justify-center rounded px-2.5 py-0.5 text-xs font-medium text-white"
+      style={{ backgroundColor: visual?.color }}
     >
-      <Icon className="h-4 w-4 shrink-0" />
-      <span>{visual?.label ?? status}</span>
-    </div>
+      {visual?.label ?? status}
+    </span>
   );
 }
 
 function PriorityCell({ priority }: { priority: string }) {
-  const Icon = PRIORITY_ICON[priority] ?? ArrowRight;
   const visual = TASK_PRIORITY_VISUAL[priority as TaskPriorityVisualKey];
   return (
-    <div
-      className="flex items-center gap-2 text-sm"
-      style={{ color: visual?.color }}
+    <span
+      className="inline-flex items-center justify-center rounded px-2.5 py-0.5 text-xs font-medium text-white"
+      style={{ backgroundColor: visual?.color }}
     >
-      <Icon className="h-4 w-4 shrink-0" />
-      <span>{visual?.label ?? priority}</span>
-    </div>
+      {visual?.label ?? priority}
+    </span>
   );
 }
 

--- a/apps/web/src/lib/task-visuals.ts
+++ b/apps/web/src/lib/task-visuals.ts
@@ -1,30 +1,30 @@
 export const TASK_STATUS_VISUAL = {
   TODO: {
     label: "Todo",
-    color: "#a5b4fc",
+    color: "#a39e98",
   },
   IN_PROGRESS: {
     label: "In Progress",
-    color: "#93c5fd",
+    color: "#0075de",
   },
   DONE: {
     label: "Done",
-    color: "#6ee7b7",
+    color: "#1aae39",
   },
 } as const;
 
 export const TASK_PRIORITY_VISUAL = {
   LOW: {
     label: "Low",
-    color: "#94a3b8",
+    color: "#a39e98",
   },
   MEDIUM: {
     label: "Medium",
-    color: "#fcd34d",
+    color: "#dd5b00",
   },
   HIGH: {
     label: "High",
-    color: "#f9a8d4",
+    color: "#e03131",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

Replaces the icon + colored text display for status and priority columns with solid color badge chips. Labels are white and centered on the task's assigned color. Colors aligned with the warm neutral design system.

## Changes

- Backend: N/A
- Frontend:
  + `TasksTable.tsx` — `StatusCell` and `PriorityCell` rewritten as `<span>` badges with `inline-flex items-center justify-center rounded px-2.5 py-0.5 text-xs font-medium text-white`; background color from `task-visuals`
  + Removed `STATUS_ICON` and `PRIORITY_ICON` record constants (no longer used)
  + Removed unused lucide imports: `CircleCheck`, `Clock3`, `ArrowUp`, `ArrowRight`, `ArrowDown`
  + `task-visuals.ts` — colors updated to match warm neutral palette: Todo/Low `#a39e98`, In Progress `#0075de`, Done `#1aae39`, Medium `#dd5b00`, High `#e03131`
  + `apps/web/SKILL.md` — added Design Tokens section documenting global palette tokens and badge color rules

## Testing

- `typecheck` passes
- Regression test: N/A (UI-only change, no logic affected)