### PR TITLE
[Web - UI] Replace required asterisk with RequiredBadge tag

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/CreateTaskDialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/CreateTaskDialog.tsx
@@ -6,6 +6,7 @@ import { createTask, type TaskFormState } from "@/app/actions/tasks";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DatePicker } from "@/components/shared/DatePicker";
+import { RequiredBadge } from "@/components/shared/RequiredBadge";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -64,8 +65,8 @@ export function CreateTaskDialog() {
 
         <form key={formKey} action={formAction} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="ct-title">
-              Title <span className="text-destructive">*</span>
+            <Label htmlFor="ct-title" className="flex items-center gap-2">
+              Title <RequiredBadge />
             </Label>
             <Input
               id="ct-title"

--- a/apps/web/src/app/(dashboard)/_components/EditTaskDialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/EditTaskDialog.tsx
@@ -6,6 +6,7 @@ import { updateTask, type TaskFormState } from "@/app/actions/tasks";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DatePicker } from "@/components/shared/DatePicker";
+import { RequiredBadge } from "@/components/shared/RequiredBadge";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -99,8 +100,8 @@ export function EditTaskDialog({
           <input type="hidden" name="id" value={task.id} />
 
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="et-title">
-              Title <span className="text-destructive">*</span>
+            <Label htmlFor="et-title" className="flex items-center gap-2">
+              Title <RequiredBadge />
             </Label>
             <Input
               id="et-title"

--- a/apps/web/src/components/shared/RequiredBadge.tsx
+++ b/apps/web/src/components/shared/RequiredBadge.tsx
@@ -1,0 +1,7 @@
+export function RequiredBadge() {
+  return (
+    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none bg-primary/10 text-primary">
+      Required
+    </span>
+  );
+}


### PR DESCRIPTION
### Summary

Replace the plain `*` asterisk used to mark required fields with a styled `RequiredBadge` tag component that aligns with the global design palette.

### Changes

- Frontend: Created `components/shared/RequiredBadge.tsx` — small pill badge with `bg-primary/10 text-primary` styling
- Frontend: Updated `CreateTaskDialog` and `EditTaskDialog` to use `<RequiredBadge />` in place of `<span className="text-destructive">*</span>`

### Testing

- Lint passes, typecheck passes
- Visually verified label renders inline with field title