### PR TITLE
[Web - UI] Unify Error Message Style Across Forms

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/CreateTaskDialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/CreateTaskDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DatePicker } from "@/components/shared/DatePicker";
 import { RequiredBadge } from "@/components/shared/RequiredBadge";
+import { FormError } from "@/components/shared/FormError";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -114,9 +115,7 @@ export function CreateTaskDialog() {
             </div>
           </div>
 
-          {state?.error && (
-            <p className="text-sm text-destructive">{state.error}</p>
-          )}
+          <FormError message={state?.error} />
 
           <div className="flex justify-end gap-3 pt-2">
             <Button

--- a/apps/web/src/app/(dashboard)/_components/EditTaskDialog.tsx
+++ b/apps/web/src/app/(dashboard)/_components/EditTaskDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DatePicker } from "@/components/shared/DatePicker";
 import { RequiredBadge } from "@/components/shared/RequiredBadge";
+import { FormError } from "@/components/shared/FormError";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -168,9 +169,7 @@ export function EditTaskDialog({
             </div>
           </div>
 
-          {state?.error && (
-            <p className="text-sm text-destructive">{state.error}</p>
-          )}
+          <FormError message={state?.error} />
 
           <div className="flex justify-end gap-3 pt-2">
             <Button


### PR DESCRIPTION
### Summary

Task dialogs (Create/Edit) were displaying server errors as plain `<p className="text-sm text-destructive">` while auth pages use the `FormError` component (styled box with icon + border). This PR makes all form errors consistent by using `FormError` everywhere.

### Changes

- Frontend: `CreateTaskDialog` — replace plain `<p>` error with `<FormError message={state?.error} />`
- Frontend: `EditTaskDialog` — same fix

### Testing

- Lint passes, typecheck passes
- Verified no regressions in error rendering logic