### PR TITLE
[Web - Auth] Unify Server Error Display On Auth Pages

### DIFF
--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthCard } from "@/app/(auth)/_components/AuthCard";
 import { TermsDialog } from "@/app/(auth)/_components/TermsDialog";
-import { FormError, FieldError } from "@/components/shared/FormError";
+import { FieldError } from "@/components/shared/FormError";
 import { cn } from "@/lib/utils";
 
 export default function LoginPage() {
@@ -71,7 +71,7 @@ export default function LoginPage() {
           <FieldError message={fieldErrors.password} />
         </div>
 
-        <FormError message={state?.error} />
+        <FieldError message={state?.error} />
 
         <Button type="submit" disabled={pending} className="mt-2 w-full">
           {pending ? "Signing in…" : "Sign in"}

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { AuthCard } from "@/app/(auth)/_components/AuthCard";
 import { TermsDialog } from "@/app/(auth)/_components/TermsDialog";
-import { FormError, FieldError } from "@/components/shared/FormError";
+import { FieldError } from "@/components/shared/FormError";
 
 const RULES = [
   {
@@ -210,7 +210,7 @@ export default function RegisterPage() {
         </div>
 
         {/* Server error */}
-        <FormError message={state?.error} />
+        <FieldError message={state?.error} />
 
         <Button type="submit" disabled={pending} className="mt-2 w-full">
           {pending ? "Registering…" : "Register"}


### PR DESCRIPTION
### Summary

Login and register pages were using `FormError` (styled box with icon + background) for server-side errors, while field validation errors used `FieldError` (small plain red text). This created a visual inconsistency on the same page.

### Changes

- Frontend: `login/page.tsx` — replace `<FormError>` with `<FieldError>` for `state?.error`
- Frontend: `register/page.tsx` — same fix

### Testing

- Lint passes, typecheck passes