### PR TITLE
[Web - UI] Fix RequiredBadge Color To Destructive

### DIFF
--- a/apps/web/src/components/shared/RequiredBadge.tsx
+++ b/apps/web/src/components/shared/RequiredBadge.tsx
@@ -1,6 +1,6 @@
 export function RequiredBadge() {
   return (
-    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none bg-primary/10 text-primary">
+    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium leading-none bg-destructive/10 text-destructive">
       Required
     </span>
   );


### PR DESCRIPTION
### Summary

`RequiredBadge` was using `bg-primary/10 text-primary` (blue) — required indicators should use the destructive/red tone to signal mandatory input.

### Changes

- Frontend: `RequiredBadge.tsx` — change to `bg-destructive/10 text-destructive`

### Testing

- Visual-only change, lint and typecheck unaffected