### PR TITLE
[Web - UI] Add Loading States With Spinner To Dashboard Routes

### DIFF
--- a/apps/web/src/app/(dashboard)/dashboard/loading.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/ui/spinner";
+
+export default function DashboardLoading() {
+  return (
+    <div className="flex h-96 items-center justify-center">
+      <Spinner className="h-6 w-6" />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/profile/loading.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/profile/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/ui/spinner";
+
+export default function ProfileLoading() {
+  return (
+    <div className="flex h-96 items-center justify-center">
+      <Spinner className="h-6 w-6" />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/tasks/loading.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tasks/loading.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@/components/ui/spinner";
+
+export default function TasksLoading() {
+  return (
+    <div className="flex h-96 items-center justify-center">
+      <Spinner className="h-6 w-6" />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/tasks/page.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/tasks/page.tsx
@@ -3,6 +3,7 @@ import { getSdkClient } from "@/lib/graphql";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { TasksTable } from "@/app/(dashboard)/_components/TasksTable";
+import { Spinner } from "@/components/ui/spinner";
 import type { GetTasksQuery, TaskFilterInput } from "@/graphql/generated";
 import { Priority, TaskStatus, SortBy, SortOrder } from "@/graphql/generated";
 
@@ -71,7 +72,7 @@ export default async function TasksPage({
         </p>
       </div>
 
-      <Suspense>
+      <Suspense fallback={<div className="flex h-64 items-center justify-center"><Spinner className="h-6 w-6" /></div>}>
         <TasksTable
           tasks={tasks}
           total={total}

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function Spinner({ className }: { className?: string }) {
+  return (
+    <Loader2 className={cn("animate-spin text-muted-foreground", className)} />
+  );
+}
+
+export { Spinner };


### PR DESCRIPTION
### Summary

Add loading states to routes that truly need them — server components with non-trivial data fetching. Auth pages and dialogs already have pending UI so they were left untouched.

### Changes

- Frontend: `components/ui/spinner.tsx` — new Spinner primitive using Lucide `Loader2 + animate-spin`
- Frontend: `components/ui/skeleton.tsx` — new Skeleton primitive (shadcn pattern, available for future use)
- Frontend: `dashboard/loading.tsx` — spinner shown while 10 parallel GraphQL queries run
- Frontend: `dashboard/tasks/loading.tsx` — spinner shown while tasks + count fetch
- Frontend: `dashboard/profile/loading.tsx` — spinner shown while user profile fetches
- Frontend: `dashboard/tasks/page.tsx` — add fallback to existing empty `<Suspense>` boundary

### Testing

- Lint passes, typecheck passes